### PR TITLE
ci(jython): run on ubuntu-latest

### DIFF
--- a/.github/workflows/jython.yml
+++ b/.github/workflows/jython.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   jython:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       JYTHON_CACHE_DIR: '~/.cache/jython'
     steps:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the Jython CI workflow to run on 'ubuntu-latest' instead of a specific version.