### PR TITLE
build(deps): use coatl-dev/docformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,8 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
+  - repo: https://github.com/coatl-dev/docformatter
+    rev: v1.7.6
     hooks:
       - id: docformatter
         args: [--in-place, --wrap-summaries=72, --close-quotes-on-newline]


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update docformatter pre-commit hook to use coatl-dev/docformatter v1.7.6.