### PR TITLE
ci(pr-build): fix glob pattern

### DIFF
--- a/.github/workflows/jython.yml
+++ b/.github/workflows/jython.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Jython
-        uses: coatl-dev/actions/setup-jython@v3
+        uses: coatl-dev/actions/setup-jython@v4
         id: setup-jython
 
       - name: Cache Jython

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/pr-build.yml'
-      - 'src/**'
+      - .github/workflows/pr-build.yml
+      - src/**
       - Makefile
       - requirements.txt
       - setup.py

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - .github/workflows/jython.yml
       - .github/workflows/pr-build.yml
       - src/**
       - Makefile


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjusted glob pattern syntax in PR build workflow trigger