### PR TITLE
refactor(db): add transaction argument

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,5 +15,5 @@
       }
     }
   },
-  "onCreateCommand": "pre-commit install && pre-commit install --hook-type commit-msg"
+  "onCreateCommand": "pre-commit install --hook-type  pre-commit --hook-type commit-msg --hook-type pre-push"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,22 @@
-## v2024.10.0 (2024-10-28)
+## 2024.10.0 (2024-10-28)
 
 ### Refactor
 
 - remove util module (#221)
 
-## v2024.5.0 (2024-05-01)
+## 2024.5.0 (2024-05-01)
 
 ### Refactor
 
 - **util**: move functions out of util (#199)
 
-## v2023.4.0 (2023-04-18)
+## 2023.4.0 (2023-04-18)
 
 ### Feat
 
 - **db**: handle concurrent DisposableConnection connections (#142)
 
-## v2023.3.0 (2023-03-30)
+## 2023.3.0 (2023-03-30)
 
 ### Feat
 
@@ -26,7 +26,7 @@
 
 - **helper**: move SProcResult from helper.types to db module (#141)
 
-## v2023.2.0 (2023-02-25)
+## 2023.2.0 (2023-02-25)
 
 ### Feat
 
@@ -36,29 +36,29 @@
 
 - **ci**: remove matrix strategy (#116)
 
-## v2023.1.0 (2023-01-09)
+## 2023.1.0 (2023-01-09)
 
 ### Refactor
 
 - add call to super in base classes (#111)
 - **ci**: run on ubuntu-20.04 (#98)
 
-## v2022.9.2 (2022-09-21)
+## 2022.9.2 (2022-09-21)
 
 ### Refactor
 
 - **db**: cast return value to str (#78)
 - **db**: return BasicDataset on get_data and o_get_data (#77)
 
-## v2022.9.1 (2022-09-03)
+## 2022.9.1 (2022-09-03)
 
 ### Fix
 
 - **db**: fix o_get_data docstring (#72)
 
-## v2022.9.0.post1 (2022-09-03)
+## 2022.9.0.post1 (2022-09-03)
 
-## v2022.9.0 (2022-09-02)
+## 2022.9.0 (2022-09-02)
 
 ### Feat
 
@@ -75,25 +75,25 @@
 
 - **exceptions**: improve repr and str functions (#71)
 
-## v2022.8.2.post1 (2022-08-23)
+## 2022.8.2.post1 (2022-08-23)
 
 ### Fix
 
 - **db**: refactor types module (#61)
 
-## v2022.8.2 (2022-08-05)
+## 2022.8.2 (2022-08-05)
 
 ### Refactor
 
 - **dataset**: work with nested Datasets on to_jsonobject (#56)
 
-## v2022.8.1 (2022-08-05)
+## 2022.8.1 (2022-08-05)
 
 ### Refactor
 
 - **db**: remove unnecessary str cast
 
-## v2022.8.0 (2022-08-05)
+## 2022.8.0 (2022-08-05)
 
 ### Feat
 
@@ -106,7 +106,7 @@
 - **dataset**: remove default value for `root` (#49)
 - **dataset**: use Dataset to check instance
 
-## v2022.3.2 (2022-03-24)
+## 2022.3.2 (2022-03-24)
 
 ### Feat
 
@@ -121,26 +121,26 @@
 - **ci**: update `ci.yml` (#38)
 - apply multiple refactorings to `dataset` (#34)
 
-## v2022.3.1 (2022-03-03)
+## 2022.3.1 (2022-03-03)
 
 ### Refactor
 
 - fix `perflint` `W8202`
 - reduce cognitive complexity
 
-## v2022.2.1 (2022-02-09)
+## 2022.2.1 (2022-02-09)
 
 ### Fix
 
 - add `get_timestamp` to `__all__`
 
-## v2022.2.0 (2022-02-09)
+## 2022.2.0 (2022-02-09)
 
 ### Feat
 
 - add `get_timestamp` function
 
-## v2.0.2 (2022-01-25)
+## 2.0.2 (2022-01-25)
 
 ### BREAKING CHANGE
 
@@ -150,13 +150,13 @@
 
 - fix SonarLint and Sourcery issues
 
-## v2.0.1 (2021-12-17)
+## 2.0.1 (2021-12-17)
 
 ### Fix
 
 - **db**: check instance of `out_params`
 
-## v2.0.0 (2021-10-20)
+## 2.0.0 (2021-10-20)
 
 ### BREAKING CHANGE
 
@@ -167,19 +167,19 @@
 
 - add InParam, OutParam and Param to db
 
-## v1.1.2 (2021-10-18)
+## 1.1.2 (2021-10-18)
 
 ### Fix
 
 - update icendium.vision.gui constants
 
-## v1.1.1 (2021-10-18)
+## 1.1.1 (2021-10-18)
 
 ### Fix
 
 - bring back gui.CURSOR* constants
 
-## v1.1.0 (2021-10-15)
+## 1.1.0 (2021-10-15)
 
 ### BREAKING CHANGE
 
@@ -198,19 +198,19 @@ Jython is no longer recommended.
 - import unicode_literals
 - remove copyright from modules
 
-## v1.0.7.post2 (2021-09-13)
+## 1.0.7.post2 (2021-09-13)
 
-## v1.0.7.post1 (2021-09-13)
+## 1.0.7.post1 (2021-09-13)
 
 ### Fix
 
 - **setup**: include `__cycle__` in package `version`
 
-## v1.0.7 (2021-09-11)
+## 1.0.7 (2021-09-11)
 
 ### Feat
 
-- **release**: v1.0.7
+- **release**: 1.0.7
 
 ### Fix
 
@@ -220,7 +220,7 @@ Jython is no longer recommended.
 
 - add pylint
 
-## v1.0.6 (2021-08-04)
+## 1.0.6 (2021-08-04)
 
 ### BREAKING CHANGE
 
@@ -236,7 +236,7 @@ used in some `system.db` functions.
 
 - conform to snake_case naming style
 
-## v1.0.5 (2021-06-22)
+## 1.0.5 (2021-06-22)
 
 ### Feat
 
@@ -252,7 +252,7 @@ used in some `system.db` functions.
 
 - modify imports
 
-## v1.0.4 (2021-02-24)
+## 1.0.4 (2021-02-24)
 
 ### Feat
 
@@ -263,6 +263,6 @@ used in some `system.db` functions.
 
 - :zap: simplify sequence comparison
 
-## v1.0.3 (2020-11-12)
+## 1.0.3 (2020-11-12)
 
-## v1.0.2 (2020-10-17)
+## 1.0.2 (2020-10-17)

--- a/src/incendium/__about__.py
+++ b/src/incendium/__about__.py
@@ -3,7 +3,7 @@
 
 __title__ = "incendium"
 __description__ = "Package that extends and wraps Ignition Scripting API"
-__url__ = "https://github.com/ignition-incendium/incendium"
+__url__ = "https://github.com/ignition-devs/incendium"
 __version__ = "2024.10.0"
 __author__ = "César Román"
 __author_email__ = "cesar@coatl.dev"

--- a/src/incendium/__init__.py
+++ b/src/incendium/__init__.py
@@ -4,5 +4,5 @@ incendium is a package that extends and wraps some functions from
 Ignition Scripting API.
 
 For more information, please refer to the Wiki.
-https://github.com/ignition-incendium/incendium/wiki
+https://github.com/ignition-devs/incendium/wiki
 """

--- a/src/incendium/db.py
+++ b/src/incendium/db.py
@@ -283,45 +283,13 @@ def _execute_sp(
     }
 
 
-def get_output_params(
+def check(
     stored_procedure,  # type: AnyStr
-    output,  # type: List[OutParam]
     database="",  # type: AnyStr
     transaction=None,  # type: Optional[AnyStr]
     params=None,  # type: Optional[List[InParam]]
 ):
-    # type: (...) -> DictIntStringAny
-    """Get the Output parameters from the Stored Procedure.
-
-    Args:
-        stored_procedure: The name of the stored procedure to execute.
-        output: A list containing all OUTPUT parameters as OutParam
-            objects.
-        database: The name of the database connection to execute
-            against. If omitted or "", the project's default database
-            connection will be used. Optional.
-        transaction: A transaction identifier. If omitted, the call will
-            be executed in its own transaction. Optional.
-        params: A list containing all INPUT parameters as InParam
-            objects. Optional.
-
-    Returns:
-        A Python dictionary of OUTPUT parameters.
-    """
-    result = _execute_sp(
-        stored_procedure,
-        database=database,
-        transaction=transaction,
-        in_params=params,
-        out_params=output,
-        get_out_params=True,
-    )
-
-    return result["output_params"]
-
-
-def check(stored_procedure, database="", params=None):
-    # type: (AnyStr, AnyStr, Optional[List[InParam]]) -> Optional[bool]
+    # type: (...) -> Optional[bool]
     """Execute a stored procedure against the connection.
 
     This will return a flag set to TRUE or FALSE.
@@ -331,17 +299,27 @@ def check(stored_procedure, database="", params=None):
         database: The name of the database connection to execute
             against. If omitted or "", the project's default database
             connection will be used. Optional.
+        transaction: A transaction identifier. If omitted, the call will
+            be executed in its own transaction. Optional.
         params: A Dictionary containing all INPUT parameters. Optional.
 
     Returns:
         The flag.
     """
-    output = OutParam("flag", system.db.BIT)
-    output_params = get_output_params(
-        stored_procedure, output=[output], database=database, params=params
+    result = _execute_sp(
+        stored_procedure,
+        database=database,
+        transaction=transaction,
+        in_params=params,
+        out_params=[OutParam("flag", system.db.BIT)],
+        get_out_params=True,
     )
 
-    return output_params["flag"] if "flag" in output_params.iterkeys() else None
+    return (
+        result["output_params"]["flag"]
+        if "flag" in result["output_params"].iterkeys()
+        else None
+    )
 
 
 def execute_non_query(
@@ -383,6 +361,7 @@ def execute_non_query(
 def get_data(
     stored_procedure,  # type: AnyStr
     database="",  # type: AnyStr
+    transaction=None,  # type: Optional[AnyStr]
     params=None,  # type: Optional[List[InParam]]
 ):
     # type: (...) -> BasicDataset
@@ -393,6 +372,8 @@ def get_data(
         database: The name of the database connection to execute
             against. If omitted or "", the project's default database
             connection will be used. Optional.
+        transaction: A transaction identifier. If omitted, the call will
+            be executed in its own transaction. Optional.
         params: A list containing all INPUT parameters as InParam
             objects. Optional.
 
@@ -403,11 +384,49 @@ def get_data(
     result = _execute_sp(
         stored_procedure,
         database=database,
+        transaction=transaction,
         in_params=params,
         get_result_set=True,
     )
 
     return result["result_set"]
+
+
+def get_output_params(
+    stored_procedure,  # type: AnyStr
+    output,  # type: List[OutParam]
+    database="",  # type: AnyStr
+    transaction=None,  # type: Optional[AnyStr]
+    params=None,  # type: Optional[List[InParam]]
+):
+    # type: (...) -> DictIntStringAny
+    """Get the Output parameters from the Stored Procedure.
+
+    Args:
+        stored_procedure: The name of the stored procedure to execute.
+        output: A list containing all OUTPUT parameters as OutParam
+            objects.
+        database: The name of the database connection to execute
+            against. If omitted or "", the project's default database
+            connection will be used. Optional.
+        transaction: A transaction identifier. If omitted, the call will
+            be executed in its own transaction. Optional.
+        params: A list containing all INPUT parameters as InParam
+            objects. Optional.
+
+    Returns:
+        A Python dictionary of OUTPUT parameters.
+    """
+    result = _execute_sp(
+        stored_procedure,
+        database=database,
+        transaction=transaction,
+        in_params=params,
+        out_params=output,
+        get_out_params=True,
+    )
+
+    return result["output_params"]
 
 
 def get_return_value(
@@ -492,6 +511,7 @@ def o_get_data(
     stored_procedure,  # type: AnyStr
     out_params,  # type: List[OutParam]
     database="",  # type: AnyStr
+    transaction=None,  # type: Optional[AnyStr]
     in_params=None,  # type: Optional[List[InParam]]
 ):
     # type: (...) -> Tuple[BasicDataset, DictIntStringAny]
@@ -504,6 +524,8 @@ def o_get_data(
         database: The name of the database connection to execute
             against. If omitted or "", the project's default database
             connection will be used. Optional.
+        transaction: A transaction identifier. If omitted, the call will
+            be executed in its own transaction. Optional.
         in_params: A list containing all INPUT parameters as InParam
             objects. Optional.
 
@@ -514,6 +536,7 @@ def o_get_data(
     result = _execute_sp(
         stored_procedure,
         database=database,
+        transaction=transaction,
         in_params=in_params,
         out_params=out_params,
         get_out_params=True,


### PR DESCRIPTION
to:
- check
- get_data
- o_get_data

## Summary by Sourcery

Introduce transaction support across database utility functions, streamline output parameter handling, and update project metadata and CHANGELOG formatting.

Enhancements:
- Add optional transaction parameter to check, get_data, o_get_data, and get_output_params functions for stored procedure execution.
- Refactor check to call _execute_sp directly with an embedded flag OutParam and streamline output handling.
- Reorganize and consolidate get_output_params logic to accept transactions and simplify output retrieval.

Documentation:
- Update project URLs in __about__.py and module docstring to new GitHub organization.

Chores:
- Standardize CHANGELOG headings by removing leading ‘v’ prefixes.