### PR TITLE
ci(pr-build): update paths filter

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -7,10 +7,12 @@ on:
     paths:
       - .github/workflows/jython.yml
       - .github/workflows/pr-build.yml
-      - src/**
-      - Makefile
-      - requirements.txt
-      - setup.py
+      - '**/requirements.txt'
+      - pkg/src/**
+      - pkg/Makefile
+      - pkg/setup.py
+      - stubs/stubs/**
+      - stubs/pyproject.toml
       - tox.ini
   workflow_call:
 


### PR DESCRIPTION
## Summary by Sourcery

Update the PR build workflow to match the new project layout by adjusting the paths filter.

CI:
- Replace root-level src/**, Makefile, requirements.txt, and setup.py filters with their counterparts under pkg/
- Add stubs directory and its pyproject.toml to the paths trigger
- Allow requirements.txt files in any subdirectory to trigger the workflow