### PR TITLE
ci(jython): set jython version to 2.7.3

### DIFF
--- a/.github/workflows/jython.yml
+++ b/.github/workflows/jython.yml
@@ -17,13 +17,13 @@ jobs:
         uses: coatl-dev/actions/setup-jython@v4
         id: setup-jython
         with:
-          java-distribution: temurin
+          jython-version: '2.7.3'
 
       - name: Cache Jython
         uses: actions/cache@v4
         with:
           path: ${{ env.JYTHON_CACHE_DIR }}
-          key: jy-${{ steps.setup-jython.outputs.jython-version }}-${{ runner.os }}-${{ steps.setup-jython.outputs.java-distribution }}-${{ steps.setup-jython.outputs.java-version }}-${{ hashFiles('setup.py') }}
+          key: jy-${{ steps.setup-jython.outputs.jython-version }}-${{ runner.os }}-${{ steps.setup-jython.outputs.java-distribution }}-${{ steps.setup-jython.outputs.java-version }}-${{ hashFiles('/incendium/setup.py') }}
 
       - name: Test installation on Jython
         working-directory: incendium

--- a/.github/workflows/jython.yml
+++ b/.github/workflows/jython.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.JYTHON_CACHE_DIR }}
-          key: jy-${{ steps.setup-jython.outputs.jython-version }}-${{ runner.os }}-${{ steps.setup-jython.outputs.java-distribution }}-${{ steps.setup-jython.outputs.java-version }}-${{ hashFiles('/incendium/setup.py') }}
+          key: jy-${{ steps.setup-jython.outputs.jython-version }}-${{ runner.os }}-${{ steps.setup-jython.outputs.java-distribution }}-${{ steps.setup-jython.outputs.java-version }}-${{ hashFiles('incendium/setup.py') }}
 
       - name: Test installation on Jython
         working-directory: incendium


### PR DESCRIPTION
fix cache key

## Summary by Sourcery

Set explicit Jython version in GitHub Actions and correct cache key hashing path

CI:
- Pin Jython version to 2.7.3 in the setup-jython action
- Update cache key to hash the correct setup.py location under /incendium