### PR TITLE
ci(pip-compile-upgrade): use coatl-dev/actions@v5

### DIFF
--- a/.github/workflows/pip-compile-upgrade.yml
+++ b/.github/workflows/pip-compile-upgrade.yml
@@ -14,15 +14,14 @@ jobs:
 
       - name: Upgrade incendium requirements
         id: pip-compile-upgrade-incendium
-        uses: coatl-dev/actions/pip-compile-upgrade@v4
+        uses: coatl-dev/actions/pip-compile-upgrade@v5
         with:
           path: requirements.txt
-          python-version: '2.7'
           working-directory: incendium
 
       - name: Upgrade incendium-stubs requirements
         id: pip-compile-upgrade-incendium-stubs
-        uses: coatl-dev/actions/uv-pip-compile-upgrade@v4
+        uses: coatl-dev/actions/uv-pip-compile-upgrade@v5
         with:
           path: requirements.txt
           python-version: '3.12'
@@ -30,14 +29,14 @@ jobs:
 
       - name: Detect changes
         id: git-diff
-        uses: coatl-dev/actions/simple-git-diff@v4
+        uses: coatl-dev/actions/simple-git-diff@v5
         with:
           path: ${{ github.workspace }}
 
       - name: Import GPG key
         if: ${{ steps.git-diff.outputs.diff == 'true' }}
         id: gpg-import
-        uses: coatl-dev/actions/gpg-import@v4
+        uses: coatl-dev/actions/gpg-import@v5
         with:
           passphrase: ${{ secrets.COATL_BOT_GPG_PASSPHRASE }}
           private-key: ${{ secrets.COATL_BOT_GPG_PRIVATE_KEY }}
@@ -62,6 +61,6 @@ jobs:
 
       - name: Create pull request
         if: ${{ steps.git-diff.outputs.diff == 'true' }}
-        uses: coatl-dev/actions/pr-create@v4
+        uses: coatl-dev/actions/pr-create@v5
         with:
           gh-token: ${{ secrets.COATL_BOT_GH_TOKEN }}


### PR DESCRIPTION
## Summary by Sourcery

Upgrade GitHub Actions used in the pip-compile-upgrade workflow to version v5 and streamline step inputs

CI:
- Update coatl-dev/actions/pip-compile-upgrade to v5 for the incendium requirements upgrade
- Upgrade coatl-dev/actions/uv-pip-compile-upgrade to v5 for the incendium-stubs requirements step
- Bump simple-git-diff, gpg-import, and pr-create actions to v5
- Remove obsolete python-version input from the incendium pip-compile-upgrade step