### PR TITLE
ci: bump coatl-dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pylint:
-    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v5
+    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v6
     with:
       path: src
       working-directory: incendium

--- a/.github/workflows/jython.yml
+++ b/.github/workflows/jython.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Jython
-        uses: coatl-dev/actions/setup-jython@v4
+        uses: coatl-dev/actions/setup-jython@v5
         id: setup-jython
         with:
           jython-version: '2.7.3'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -21,12 +21,12 @@ jobs:
     uses: ./.github/workflows/jython.yml
 
   tox-incendium:
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v5
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v6
     with:
       working-directory: incendium
 
   tox-incendium-stubs:
-    uses: coatl-dev/workflows/.github/workflows/tox-gh.yml@v5
+    uses: coatl-dev/workflows/.github/workflows/tox-gh.yml@v6
     with:
       python-versions: '["3.9", "3.10", "3.11", "3.12"]'
       working-directory: incendium-stubs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,16 +15,15 @@ jobs:
 
   publish-incendium:
     needs: pr-build
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v5
+    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v6
     with:
-      python-version: '2.7'
       working-directory: incendium
     secrets:
       password: ${{ secrets.PYPI_API_TOKEN_INCENDIUM_PKG }}
 
   publish-incendium-stubs:
     needs: pr-build
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v5
+    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v6
     with:
       python-version: '3.12'
       working-directory: incendium-stubs


### PR DESCRIPTION
actions: from v4 to v5
workflows: from v5 to v6

## Summary by Sourcery

Update GitHub Actions dependencies to newer versions of coatl-dev workflows and actions.

CI:
- Bump coatl-dev/workflows actions (pypi-upload, tox-docker, tox-gh, pylint) from v5 to v6 across all workflow files
- Upgrade coatl-dev/actions/setup-jython from v4 to v5 in jython.yml