### PR TITLE
build(deps): add pydoclint as a dependency for flake8 hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 ci:
   autoupdate_commit_msg: 'build(deps): pre-commit autoupdate'
+  autofix_commit_msg: 'style: apply auto fixes with pre-commit'
   skip:
     - pylint
 
@@ -52,6 +53,7 @@ repos:
         name: flake8-incendium
         args: [--config=incendium/tox.ini]
         files: ^incendium/src/
+        additional_dependencies: [pydoclint]
   - repo: https://github.com/PyCQA/flake8
     rev: 7.3.0
     hooks:
@@ -67,12 +69,6 @@ repos:
       - id: pydocstyle
         files: ^incendium/src/
         args: [--config=incendium/tox.ini]
-  - repo: https://github.com/jsh9/pydoclint
-    rev: 0.6.7
-    hooks:
-      - id: pydoclint-flake8
-        files: ^incendium/src/
-        args: [--config=incendium/tox.ini, --extend-ignore=F401]
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v4.8.3
     hooks:

--- a/incendium/tox.ini
+++ b/incendium/tox.ini
@@ -28,6 +28,38 @@ deps =
 commands =
     stubgen --export-less --output=..{/}incendium-stubs{/}stubs src
 
+[testenv:style]
+description = apply style
+base_python = python3.12
+skip_install = true
+deps =
+    black
+    docformatter
+    flake8==5.0.4
+    isort
+    pydoclint
+    pydocstyle
+    sort-all
+    ssort
+    unimport
+commands =
+    python -c \
+      "import pathlib, subprocess; \
+      files = [str(p) for p in pathlib.Path('src').rglob('*.py')]; \
+      subprocess.run(['sort-all'] + files, check=True)"
+    ssort src
+    black --quiet src
+    unimport src
+    isort --settings-file=tox.ini src
+    docformatter \
+      --in-place \
+      --wrap-summaries 72 \
+      --close-quotes-on-newline \
+      --recursive \
+      src
+    flake8 --select=DOC --config=tox.ini src
+    pydocstyle --config=tox.ini src{/}system
+
 [type]
 base_python = python3.12
 deps =
@@ -43,9 +75,10 @@ ignore = DOC301, F821
 max-complexity = 10
 max-doc-length = 72
 max-line-length = 88
+# pydoclint
 style = google
-arg-type-hints-in-signature = False
 arg-type-hints-in-docstring = False
+arg-type-hints-in-signature = False
 check-return-types = False
 
 [isort]


### PR DESCRIPTION
update flake8 configuration
add back the style testenv for tox

## Summary by Sourcery

Introduce a dedicated style test environment, integrate pydoclint into the Flake8 pipeline, and refine pre-commit settings for auto-fixing and commit messaging.

New Features:
- Add a new tox testenv 'style' for unified code formatting and linting using black, isort, docformatter, sort-all, ssort, unimport, flake8, pydoclint, and pydocstyle.

Enhancements:
- Extend Flake8 configuration to run pydoclint checks under Google docstring style and merge DOC rules configuration.
- Remove the standalone pydoclint-flake8 hook in pre-commit and add pydoclint as an additional dependency to the flake8-incendium hook.

CI:
- Add autofix_commit_msg template in pre-commit autoupdate configuration.