### PR TITLE
refactor(db): remove _Param class

### DIFF
--- a/incendium-stubs/stubs/incendium/db.pyi
+++ b/incendium-stubs/stubs/incendium/db.pyi
@@ -4,20 +4,6 @@ from typing import Any, List, Optional, Tuple, Type, Union
 from com.inductiveautomation.ignition.common import BasicDataset
 from incendium.helper.types import AnyStr, DictIntStringAny
 
-class _Param:
-    def __init__(
-        self,
-        name_or_index: Union[int, AnyStr],
-        type_code: int,
-        value: Optional[Any] = ...,
-    ) -> None: ...
-    @property
-    def name_or_index(self) -> Union[int, AnyStr]: ...
-    @property
-    def type_code(self) -> int: ...
-    @property
-    def value(self) -> Optional[Any]: ...
-
 class DisposableConnection:
     def __init__(self, database: AnyStr, retries: int = ...) -> None: ...
     @property
@@ -32,13 +18,23 @@ class DisposableConnection:
         exc_tb: Optional[TracebackType],
     ) -> None: ...
 
-class InParam(_Param):
+class InParam:
     def __init__(
         self, name_or_index: Union[int, AnyStr], type_code: int, value: Any
     ) -> None: ...
+    @property
+    def name_or_index(self) -> Union[int, AnyStr]: ...
+    @property
+    def type_code(self) -> int: ...
+    @property
+    def value(self) -> Optional[Any]: ...
 
-class OutParam(_Param):
+class OutParam:
     def __init__(self, name_or_index: Union[int, AnyStr], type_code: int) -> None: ...
+    @property
+    def name_or_index(self) -> Union[int, AnyStr]: ...
+    @property
+    def type_code(self) -> int: ...
 
 class TransactionManager:
     transaction_id: str

--- a/incendium/src/incendium/db.py
+++ b/incendium/src/incendium/db.py
@@ -24,61 +24,6 @@ from java.lang import Thread
 
 from incendium.helper.types import AnyStr, DictIntStringAny
 
-
-class _Param(object):
-    """Base class used for defining [IN|OUT]PUT parameters."""
-
-    def __init__(
-        self,
-        name_or_index,  # type: Union[int, AnyStr]
-        type_code,  # type: int
-        value=None,  # type: Optional[Any]
-    ):
-        # type: (...) -> None
-        """Param object initializer.
-
-        Args:
-            name_or_index: Parameter name or index.
-            type_code: Type code constant.
-            value: Value of type type_code.
-        """
-        super(_Param, self).__init__()
-        self._name_or_index = name_or_index
-        self._type_code = type_code
-        self._value = value
-
-    @property
-    def name_or_index(self):
-        # type: () -> Union[int, AnyStr]
-        """Get value of name_or_index."""
-        return self._name_or_index
-
-    @property
-    def type_code(self):
-        # type: () -> int
-        """Get value of type_code."""
-        return self._type_code
-
-    @property
-    def value(self):
-        # type: () -> Optional[Any]
-        """Get value of value."""
-        return self._value
-
-    def __repr__(self):  # type: ignore[no-untyped-def]
-        """Compute the "official" string representation."""
-        return "{}(name_or_index={!r}, type_code={}, value={})".format(
-            self.__class__.__name__,
-            self.name_or_index,
-            self.type_code,
-            self.value,
-        )
-
-    def __str__(self):  # type: ignore[no-untyped-def]
-        """Compute the "informal" string representation."""
-        return "{!r}, {}, {}".format(self.name_or_index, self.type_code, self.value)
-
-
 _SProcResult = TypedDict(
     "_SProcResult",
     {
@@ -172,7 +117,7 @@ class DisposableConnection(object):
             system.db.setDatasourceEnabled(self._database, False)
 
 
-class InParam(_Param):
+class InParam(object):
     """Class used for declaring INPUT parameters."""
 
     def __init__(self, name_or_index, type_code, value):
@@ -185,10 +130,43 @@ class InParam(_Param):
             type_code: Type code constant from `system.db`.
             value: Value of type type_code.
         """
-        super(InParam, self).__init__(name_or_index, type_code, value)
+        super(InParam, self).__init__()
+        self._name_or_index = name_or_index
+        self._type_code = type_code
+        self._value = value
+
+    @property
+    def name_or_index(self):
+        # type: () -> Union[int, AnyStr]
+        """Get value of name_or_index."""
+        return self._name_or_index
+
+    @property
+    def type_code(self):
+        # type: () -> int
+        """Get value of type_code."""
+        return self._type_code
+
+    @property
+    def value(self):
+        # type: () -> Optional[Any]
+        """Get value of value."""
+        return self._value
+
+    def __repr__(self):  # type: ignore[no-untyped-def]
+        """Compute the "official" string representation."""
+        return "InParam(name_or_index={!r}, type_code={}, value={})".format(
+            self.name_or_index,
+            self.type_code,
+            self.value,
+        )
+
+    def __str__(self):  # type: ignore[no-untyped-def]
+        """Compute the "informal" string representation."""
+        return "{!r}, {}, {}".format(self.name_or_index, self.type_code, self.value)
 
 
-class OutParam(_Param):
+class OutParam(object):
     """Class used for declaring OUTPUT parameters."""
 
     def __init__(self, name_or_index, type_code):
@@ -200,7 +178,32 @@ class OutParam(_Param):
                 (str).
             type_code: Type code constant from `system.db`.
         """
-        super(OutParam, self).__init__(name_or_index, type_code)
+        super(OutParam, self).__init__()
+        self._name_or_index = name_or_index
+        self._type_code = type_code
+
+    @property
+    def name_or_index(self):
+        # type: () -> Union[int, AnyStr]
+        """Get value of name_or_index."""
+        return self._name_or_index
+
+    @property
+    def type_code(self):
+        # type: () -> int
+        """Get value of type_code."""
+        return self._type_code
+
+    def __repr__(self):  # type: ignore[no-untyped-def]
+        """Compute the "official" string representation."""
+        return "OutParam(name_or_index={!r}, type_code={})".format(
+            self.name_or_index,
+            self.type_code,
+        )
+
+    def __str__(self):  # type: ignore[no-untyped-def]
+        """Compute the "informal" string representation."""
+        return "{!r}, {}".format(self.name_or_index, self.type_code)
 
 
 class TransactionManager(object):


### PR DESCRIPTION
merge its functionality into InParam and OutParam

## Summary by Sourcery

Refactor parameter classes by eliminating the _Param base class and inlining its properties and methods into the public InParam and OutParam classes, and update the corresponding type stubs.

Enhancements:
- Remove the private _Param base class and merge its functionality directly into InParam and OutParam
- Update stub definitions to reflect the inlined InParam and OutParam properties