### PR TITLE
ci: switch from blacksmith to github

### DIFF
--- a/.github/workflows/jython.yml
+++ b/.github/workflows/jython.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   jython:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       JYTHON_CACHE_DIR: '~/.cache/jython'
     steps:

--- a/.github/workflows/pip-compile-upgrade.yml
+++ b/.github/workflows/pip-compile-upgrade.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pip-compile-upgrade:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update Jython and pip-compile-upgrade workflows to use ubuntu-latest runner instead of blacksmith-2vcpu-ubuntu-2404