### PR TITLE
chore: ignition-devs/copier-templates@04.14

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 0.4.13
+_commit: 0.4.14
 _src_path: gh:ignition-devs/copier-templates
 author_email: cesar@coatl.dev
 author_fullname: César Román

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,7 +22,7 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 
-[*.{ini,py}]
+[*.{ini,py,pyi}]
 indent_size = 4
 indent_style = space
 insert_final_newline = true

--- a/tox.ini
+++ b/tox.ini
@@ -30,19 +30,19 @@ commands =
     stubgen --export-less --output=stubs{/}stubs src
 
 [docformatter]
-in-place = true
 close-quotes-on-newline = true
+in-place = true
 wrap-summaries = 72
 
 [flake8]
+arg-type-hints-in-docstring = False
+arg-type-hints-in-signature = False
+check-return-types = False
 ignore = DOC301, F821
 max-complexity = 10
 max-doc-length = 72
 max-line-length = 88
 style = google
-arg-type-hints-in-docstring = False
-arg-type-hints-in-signature = False
-check-return-types = False
 
 [isort]
 extra_standard_library = typing


### PR DESCRIPTION
## Summary by Sourcery

Update project configuration to align with copier template version 0.4.14 and adjust linting/formatting settings accordingly.

Enhancements:
- Reorder docformatter options and refine flake8 configuration for argument type hints and return type checks.

Build:
- Update Copier template reference to version 0.4.14 in .copier-answers.yml.