### PR TITLE
chore: update to ignition-devs/copier-templates@0.4.19

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 0.4.17
+_commit: 0.4.19
 _src_path: gh:ignition-devs/copier-templates
 author_email: cesar@coatl.dev
 author_fullname: César Román

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,8 @@ repos:
     rev: 1.3.1
     hooks:
       - id: unimport
-        files: ^src/
         language_version: python3.12
+        files: ^src/
   - repo: https://github.com/PyCQA/isort
     rev: 9.0.0a3
     hooks:
@@ -35,26 +35,26 @@ repos:
     rev: v1.7.8
     hooks:
       - id: docformatter
-        args: [--config, tox.ini]
         files: ^src/
+        args: [--config, tox.ini]
   - repo: https://github.com/coatl-dev/flake8
     rev: 5.0.4
     hooks:
       - id: flake8
         name: flake8-package
-        args: [--config=tox.ini]
-        files: ^src/
-        additional_dependencies: [pydoclint]
         language_version: python3.12
+        files: ^src/
+        args: [--config=tox.ini]
+        additional_dependencies: [pydoclint]
   - repo: https://github.com/PyCQA/flake8
     rev: 7.3.0
     hooks:
       - id: flake8
         name: flake8-stubs
-        types: [file]
         files: \.(pyi)$
-        additional_dependencies: [flake8-pyi]
+        types: [file]
         args: [--config=stubs/tox.ini]
+        additional_dependencies: [flake8-pyi]
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 6.3.0
     hooks:


### PR DESCRIPTION
## Summary by Sourcery

Update project scaffolding configuration to align with copier-templates 0.4.19 and refresh pre-commit hook settings.

Build:
- Bump Copier template reference in .copier-answers.yml from 0.4.17 to 0.4.19 to sync with the latest project template.

CI:
- Tidy pre-commit hook configuration by reordering and explicitly specifying language versions and arguments for Python linting and formatting hooks.