### PR TITLE
refactor(exceptions): update JavaError's inner_exception type

### DIFF
--- a/src/incendium/exceptions.py
+++ b/src/incendium/exceptions.py
@@ -49,13 +49,13 @@ class JavaError(Exception):
     """Java Error class."""
 
     cause = None  # type: Optional[Throwable]
-    inner_exception = None  # type: InnerException
+    inner_exception = None  # type: Optional[InnerException]
     message = None  # type: AnyStr
 
     def __init__(
         self,
         message,  # type: AnyStr
-        inner_exception=None,  # type: InnerException
+        inner_exception=None,  # type: Optional[InnerException]
         cause=None,  # type: Optional[Throwable]
         remove_substring=None,  # type: Optional[AnyStr]
     ):
@@ -105,7 +105,7 @@ class GatewayError(JavaError):
     def __init__(
         self,
         message,  # type: AnyStr
-        inner_exception=None,  # type: InnerException
+        inner_exception=None,  # type: Optional[InnerException]
         cause=None,  # type: Optional[Throwable]
     ):
         # type: (...) -> None
@@ -127,7 +127,7 @@ class MSSQLError(JavaError):
     def __init__(
         self,
         message,  # type: AnyStr
-        inner_exception=None,  # type: InnerException
+        inner_exception=None,  # type: Optional[InnerException]
         cause=None,  # type: Optional[Throwable]
     ):
         # type: (...) -> None

--- a/stubs/stubs/incendium/exceptions.pyi
+++ b/stubs/stubs/incendium/exceptions.pyi
@@ -9,12 +9,12 @@ class Error(Exception):
 
 class JavaError(Exception):
     cause: Optional[Throwable]
-    inner_exception: InnerException
+    inner_exception: Optional[InnerException]
     message: AnyStr
     def __init__(
         self,
         message: AnyStr,
-        inner_exception: InnerException = ...,
+        inner_exception: Optional[InnerException] = ...,
         cause: Optional[Throwable] = ...,
         remove_substring: Optional[AnyStr] = ...,
     ) -> None: ...
@@ -25,7 +25,7 @@ class GatewayError(JavaError):
     def __init__(
         self,
         message: AnyStr,
-        inner_exception: InnerException = ...,
+        inner_exception: Optional[InnerException] = ...,
         cause: Optional[Throwable] = ...,
     ) -> None: ...
 
@@ -33,7 +33,7 @@ class MSSQLError(JavaError):
     def __init__(
         self,
         message: AnyStr,
-        inner_exception: InnerException = ...,
+        inner_exception: Optional[InnerException] = ...,
         cause: Optional[Throwable] = ...,
     ) -> None: ...
 


### PR DESCRIPTION
make it Optional

## Summary by Sourcery

Enhancements:
- Relax the type of JavaError.inner_exception and constructors (including GatewayError and MSSQLError) to Optional[InnerException] in both implementation and stubs for better typing accuracy.