### PR TITLE
build(deps): update pre-commit config from copier template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 0.4.21
+_commit: 0.4.22
 _src_path: gh:ignition-devs/copier-templates
 author_email: cesar@coatl.dev
 author_fullname: César Román

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: ssort
         files: ^src/
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
       - id: black
   - repo: https://github.com/hakancelikdev/unimport
@@ -62,7 +62,7 @@ repos:
         files: ^src/
         args: [--config=tox.ini]
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.13.10
+    rev: v4.16.2
     hooks:
       - id: commitizen
       - id: commitizen-branch


### PR DESCRIPTION
## Summary by Sourcery

Update pre-commit configuration and Copier template reference to the latest versions.

Build:
- Bump Black pre-commit hook version from 26.3.1 to 26.5.1.
- Bump Commitizen pre-commit hook version from v4.13.10 to v4.16.2.
- Update Copier template commit reference from 0.4.21 to 0.4.22 in .copier-answers.yml.