### PR TITLE
chore: bump ignition-devs/copier-templates to 0.4.25

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 0.4.22
+_commit: 0.4.25
 _src_path: gh:ignition-devs/copier-templates
 author_email: cesar@coatl.dev
 author_fullname: César Román

--- a/.gitignore
+++ b/.gitignore
@@ -313,12 +313,7 @@ poetry.toml
 pyrightconfig.json
 
 ### VisualStudioCode ###
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
+.vscode/
 
 # Local History for Visual Studio Code
 .history/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,9 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/hakancelikdev/unimport
-    rev: 1.3.1
+    rev: 1.4.0
     hooks:
       - id: unimport
-        language_version: python3.12
         files: ^src/
   - repo: https://github.com/PyCQA/isort
     rev: 9.0.0a3
@@ -62,7 +61,7 @@ repos:
         files: ^src/
         args: [--config=tox.ini]
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.2
+    rev: v4.16.3
     hooks:
       - id: commitizen
       - id: commitizen-branch


### PR DESCRIPTION
## Summary by Sourcery

Update development tooling configuration to align with the latest copier template version and associated pre-commit hooks.

Build:
- Bump copier template reference in .copier-answers.yml from 0.4.22 to 0.4.25.

CI:
- Update pre-commit hook versions for unimport and commitizen and simplify unimport configuration by relying on default Python version.

Chores:
- Refresh repository metadata and tooling configuration in line with upstream template updates.