### PR TITLE
refactor(net): add report_error to stubs

### DIFF
--- a/src/incendium/constants.py
+++ b/src/incendium/constants.py
@@ -2,6 +2,40 @@
 
 from __future__ import unicode_literals
 
+__all__ = [
+    "CANCEL_TEXT",
+    "CANNOT_DELETE_ELEMENT",
+    "CANNOT_EDIT_ELEMENT",
+    "CONFIRM",
+    "DEFAULT_LANGUAGE",
+    "EDIT_ERROR",
+    "EDIT_SUCCESS",
+    "EDIT_SUCCESS_WITH_ERRORS",
+    "EMPTY_STRING",
+    "ERROR_REPORT",
+    "ERROR_WINDOW_TITLE",
+    "FORM_ERROR",
+    "GATEWAY_EXCEPTION",
+    "INFO_WINDOW_TITLE",
+    "MSSQL_SERVER_EXCEPTION",
+    "NEW_LINE",
+    "NEW_TABBED_LINE",
+    "NO_TEXT",
+    "OK_TEXT",
+    "PROCEED_WITHOUT_SAVING_CHANGES",
+    "PROCEED_WITH_ROWS_DELETION",
+    "PROCEED_WITH_ROW_DELETION",
+    "PROCEED_WITH_SAVING_CHANGES",
+    "SENDER",
+    "SMTP",
+    "SUCCESS_WINDOW_TITLE",
+    "TABBED_LINE",
+    "UNEXPECTED_ERROR",
+    "UNEXPECTED_ERROR_CAUSED_BY",
+    "WARNING_WINDOW_TITLE",
+    "YES_TEXT",
+]
+
 # Email settings.
 SMTP = "mail.mycompany.com:25"
 SENDER = "no-reply@mycompany.com"

--- a/src/incendium/helper/types.py
+++ b/src/incendium/helper/types.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Optional, Union
 
 from java.lang import Exception as JavaException
 
+__all__ = ["AnyStr", "DictIntStringAny", "DictStringAny", "InnerException", "Number"]
+
 AnyStr = Union[str, unicode]
 DictIntStringAny = Dict[Union[int, str, unicode], Any]
 DictStringAny = Dict[Union[str, unicode], Any]

--- a/src/incendium/net.py
+++ b/src/incendium/net.py
@@ -3,12 +3,14 @@
 from __future__ import unicode_literals
 
 __all__ = [
+    "HTML_ESCAPE_TABLE",
+    "report_error",
     "send_high_priority_email",
     "send_html_email",
     "send_plain_text_email",
 ]
 
-from typing import List
+from typing import Dict, List
 
 import system.net
 
@@ -23,7 +25,7 @@ HTML_ESCAPE_TABLE = {
     "<": "&lt;",
     "\n": "<br />",
     "\t": "&nbsp;" * 4,
-}
+}  # type: Dict[AnyStr, AnyStr]
 
 
 def _html_escape(text):

--- a/stubs/stubs/incendium/net.pyi
+++ b/stubs/stubs/incendium/net.pyi
@@ -1,12 +1,17 @@
-from typing import List
+from typing import Dict, List
 
 from incendium.helper.types import AnyStr
+
+HTML_ESCAPE_TABLE: Dict[AnyStr, AnyStr]
 
 def send_html_email(
     subject: AnyStr, body: AnyStr, to: List[AnyStr], priority: AnyStr = ...
 ) -> None: ...
 def send_high_priority_email(
     subject: AnyStr, body: AnyStr, to: List[AnyStr]
+) -> None: ...
+def report_error(
+    subject: AnyStr, message: AnyStr, details: AnyStr, to: List[AnyStr]
 ) -> None: ...
 def send_plain_text_email(
     subject: AnyStr, body: AnyStr, to: List[AnyStr], priority: AnyStr = ...


### PR DESCRIPTION
update __all__ with unexport

## Summary by Sourcery

Define explicit public exports for core modules and extend network stubs to cover new error reporting functionality.

New Features:
- Add type stub for the net.report_error helper to report detailed errors via email.
- Expose the HTML_ESCAPE_TABLE mapping in the net stubs for external use.

Enhancements:
- Declare __all__ in constants and helper.types to explicitly control their public APIs.
- Annotate the HTML_ESCAPE_TABLE in net with a precise type to improve type checking and clarity.