### PR TITLE
chore: bump ignition-devs/copier-templates to 0.4.27

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 0.4.25
+_commit: 0.4.27
 _src_path: gh:ignition-devs/copier-templates
 author_email: cesar@coatl.dev
 author_fullname: César Román

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,13 @@ on:
 
 jobs:
   pre-commit:
-    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v6
+    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
     with:
       skip-hooks: 'pylint'
 
   pylint:
     needs: pre-commit
-    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v6
+    uses: coatl-dev/workflows/.github/workflows/pylint.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
 
   jython:
     if: ${{ github.event_name == 'pull_request' }}
@@ -24,16 +24,16 @@ jobs:
       JYTHON_CACHE_DIR: $HOME/.cache/jython
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Jython
-        uses: coatl-dev/actions/setup-jython@v5
+        uses: coatl-dev/actions/setup-jython@208567f6e604baf94c6e867ec7f345ec9ad36eb4 # v7.0.0
         id: setup-jython
         with:
           jython-version: '2.7.3'
 
       - name: Cache Jython
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.JYTHON_CACHE_DIR }}
           key: jy-${{ steps.setup-jython.outputs.jython-version }}-${{ runner.os }}-${{ steps.setup-jython.outputs.java-distribution }}-${{ steps.setup-jython.outputs.java-version }}-${{ hashFiles('setup.py') }}
@@ -44,11 +44,11 @@ jobs:
 
   tox-package:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v6
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
 
   tox-stubs:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: coatl-dev/workflows/.github/workflows/tox.yml@v6
+    uses: coatl-dev/workflows/.github/workflows/tox.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
     with:
       python-versions: |
         3.9

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   tox-package:
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v6
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
 
   tox-stubs:
-    uses: coatl-dev/workflows/.github/workflows/tox.yml@v6
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: coatl-dev/workflows/.github/workflows/tox.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
     with:
       python-versions: |
         3.9
@@ -21,7 +23,7 @@ jobs:
 
   pypi-publish-package:
     needs: [tox-package]
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v6
+    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
     with:
       python-version: '2.7'
       url: 'https://upload.pypi.org/legacy/'
@@ -31,7 +33,7 @@ jobs:
 
   pypi-publish-stubs:
     needs: [tox-stubs]
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v6
+    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
     with:
       python-version: '3.12'
       url: 'https://upload.pypi.org/legacy/'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,12 +60,6 @@ repos:
       - id: pydocstyle
         files: ^src/
         args: [--config=tox.ini]
-  - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.3
-    hooks:
-      - id: commitizen
-      - id: commitizen-branch
-        stages: [pre-push]
   - repo: local
     hooks:
       - id: pylint
@@ -74,3 +68,9 @@ repos:
         language: system
         files: ^src/
         types: [python]
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.16.3
+    hooks:
+      - id: commitizen
+      - id: commitizen-branch
+        stages: [pre-push]


### PR DESCRIPTION
## Summary by Sourcery

Update CI and publish workflows to use pinned v7 coatl-dev reusable workflows and actions, and refresh Copier template metadata.

Build:
- Reorder and retain Commitizen pre-commit hooks without changing their configuration.

CI:
- Pin pre-commit, pylint, tox, and tox-docker reusable workflows and related GitHub actions to specific v7 SHAs in CI.
- Restrict tox-package and tox-stubs jobs in the publish workflow to run only on pull requests and use pinned v7 SHAs.

Chores:
- Bump Copier template reference from 0.4.25 to 0.4.27 in Copier answers metadata.