### PR TITLE
ci: bump coatl-dev/workflows from v7.0.0 to v7.0.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 0.4.27
+_commit: 0.4.28
 _src_path: gh:ignition-devs/copier-templates
 author_email: cesar@coatl.dev
 author_fullname: César Román

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,13 @@ on:
 
 jobs:
   pre-commit:
-    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
+    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@395018a3c81c2a88aac15fd87a373280c70675c0 # v7.0.1
     with:
       skip-hooks: 'pylint'
 
   pylint:
     needs: pre-commit
-    uses: coatl-dev/workflows/.github/workflows/pylint.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
+    uses: coatl-dev/workflows/.github/workflows/pylint.yml@395018a3c81c2a88aac15fd87a373280c70675c0 # v7.0.1
 
   jython:
     if: ${{ github.event_name == 'pull_request' }}
@@ -44,11 +44,11 @@ jobs:
 
   tox-package:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@395018a3c81c2a88aac15fd87a373280c70675c0 # v7.0.1
 
   tox-stubs:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: coatl-dev/workflows/.github/workflows/tox.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
+    uses: coatl-dev/workflows/.github/workflows/tox.yml@395018a3c81c2a88aac15fd87a373280c70675c0 # v7.0.1
     with:
       python-versions: |
         3.9

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,11 +8,11 @@ on:
 jobs:
   tox-package:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@395018a3c81c2a88aac15fd87a373280c70675c0 # v7.0.1
 
   tox-stubs:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: coatl-dev/workflows/.github/workflows/tox.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
+    uses: coatl-dev/workflows/.github/workflows/tox.yml@395018a3c81c2a88aac15fd87a373280c70675c0 # v7.0.1
     with:
       python-versions: |
         3.9
@@ -23,7 +23,7 @@ jobs:
 
   pypi-publish-package:
     needs: [tox-package]
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
+    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@395018a3c81c2a88aac15fd87a373280c70675c0 # v7.0.1
     with:
       python-version: '2.7'
       url: 'https://upload.pypi.org/legacy/'
@@ -33,7 +33,7 @@ jobs:
 
   pypi-publish-stubs:
     needs: [tox-stubs]
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@8d3c0aba2a053986bce9382063facccf1fd98247 # v7.0.0
+    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@395018a3c81c2a88aac15fd87a373280c70675c0 # v7.0.1
     with:
       python-version: '3.12'
       url: 'https://upload.pypi.org/legacy/'


### PR DESCRIPTION
courtesy of ignition-devs/copier-templates@0.4.28

## Summary by Sourcery

Update shared CI and release workflows to the latest coatl-dev/workflows and copier template revisions.

CI:
- Bump coatl-dev/workflows GitHub Actions used for pre-commit, pylint, tox, and PyPI upload from v7.0.0 to v7.0.1.

Chores:
- Update Copier template metadata to reference ignition-devs/copier-templates 0.4.28.