### PR TITLE
ci(deps): bump dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    exclude-paths:
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/publish.yml"

--- a/.github/workflows/pip-compile-upgrade.yml
+++ b/.github/workflows/pip-compile-upgrade.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Upgrade package requirements
         id: pip-compile-upgrade-package
-        uses: coatl-dev/actions/pip-compile-upgrade@v5
+        uses: coatl-dev/actions/pip-compile-upgrade@826b5cb5dce2da7cffd0f9cf9b64ba0bd3a616d6 # v7.0.1
         with:
           path: requirements.txt
 
       - name: Upgrade stubs requirements
         id: pip-compile-upgrade-stubs
-        uses: coatl-dev/actions/uv-pip-compile-upgrade@v5
+        uses: coatl-dev/actions/uv-pip-compile-upgrade@826b5cb5dce2da7cffd0f9cf9b64ba0bd3a616d6 # v7.0.1
         with:
           path: requirements.txt
           python-version: '3.12'
@@ -28,14 +28,14 @@ jobs:
 
       - name: Detect changes
         id: git-diff
-        uses: coatl-dev/actions/simple-git-diff@v5
+        uses: coatl-dev/actions/simple-git-diff@826b5cb5dce2da7cffd0f9cf9b64ba0bd3a616d6 # v7.0.1
         with:
           path: ${{ github.workspace }}
 
       - name: Import GPG key
         if: ${{ steps.git-diff.outputs.diff == 'true' }}
         id: gpg-import
-        uses: coatl-dev/actions/gpg-import@v5
+        uses: coatl-dev/actions/gpg-import@826b5cb5dce2da7cffd0f9cf9b64ba0bd3a616d6 # v7.0.1
         with:
           passphrase: ${{ secrets.COATL_BOT_GPG_PASSPHRASE }}
           private-key: ${{ secrets.COATL_BOT_GPG_PRIVATE_KEY }}
@@ -60,6 +60,6 @@ jobs:
 
       - name: Create pull request
         if: ${{ steps.git-diff.outputs.diff == 'true' }}
-        uses: coatl-dev/actions/pr-create@v5
+        uses: coatl-dev/actions/pr-create@826b5cb5dce2da7cffd0f9cf9b64ba0bd3a616d6 # v7.0.1
         with:
           gh-token: ${{ secrets.COATL_BOT_GH_TOKEN }}


### PR DESCRIPTION
actions/chachout: v6 to v7.0.0
coatl-dev/actions: from v5 to v7.0.1

## Summary by Sourcery

Update GitHub Actions dependencies and configure automated dependency updates for actions.

CI:
- Bump actions/checkout from v6 to v7.0.0 in the pip-compile-upgrade workflow.
- Bump coatl-dev/actions composite actions from v5 to v7.0.1 in the pip-compile-upgrade workflow.
- Add a Dependabot configuration to manage monthly GitHub Actions dependency updates, excluding core CI and publish workflows.